### PR TITLE
worker handle_exception should not require a message on the exception

### DIFF
--- a/lib/ant/worker.ex
+++ b/lib/ant/worker.ex
@@ -174,7 +174,7 @@ defmodule Ant.Worker do
 
     error = %{
       attempt: attempts,
-      error: exception.message,
+      error: Map.get(exception, :message, inspect(exception)),
       stack_trace: Exception.format_stacktrace(stack_trace),
       attempted_at: DateTime.utc_now()
     }


### PR DESCRIPTION
The worker `handle_exception` is making an assumption about the exception.
The use case I am looking to solve for, is not handling every possible response from a Req request, and allowing the Ant worker handle retries on intermittent failures.

For example, [FunctionClauseErrors](https://hexdocs.pm/elixir/1.18.4/FunctionClauseError.html) don't have a message element, which then results in the Worker's GenServer to terminate prior to setting the status.

Without the `Map.get`

```bash
......
15:24:23.116 [error] GenServer #PID<0.319.0> terminating
** (KeyError) key :message not found in: %FunctionClauseError{
  module: Ant.WorkerTest.ExceptionWorkerHandlesExceptionWithoutMessage,
  function: :whoops,
  arity: 1,
  kind: nil,
  args: nil,
  clauses: nil
}
    (ant 0.0.2) lib/ant/worker.ex:177: Ant.Worker.handle_exception/3
    (stdlib 5.2) gen_server.erl:1121: :gen_server.try_handle_cast/3
    (stdlib 5.2) gen_server.erl:1183: :gen_server.handle_msg/6
    (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", :perform}
State: %{worker: %Ant.Worker{id: 1346, worker_module: Ant.WorkerTest.ExceptionWorkerHandlesExceptionWithoutMessage, queue_name: "default", args: %{a: 1}, status: :enqueued, attempts: 0, scheduled_at: ~U[2025-07-15 19:24:23.115069Z], updated_at: ~U[2025-07-15 19:24:23.115076Z], errors: [], opts: [max_attempts: 3]}}


  1) test perform/1 handles exceptions without message gracefully (Ant.WorkerTest)
     test/worker_test.exs:230
     ** (EXIT from #PID<0.315.0>) an exception was raised:
         ** (KeyError) key :message not found in: %FunctionClauseError{
       module: Ant.WorkerTest.ExceptionWorkerHandlesExceptionWithoutMessage,
       function: :whoops,
       arity: 1,
       kind: nil,
       args: nil,
       clauses: nil
     }
             (ant 0.0.2) lib/ant/worker.ex:177: Ant.Worker.handle_exception/3
             (stdlib 5.2) gen_server.erl:1121: :gen_server.try_handle_cast/3
             (stdlib 5.2) gen_server.erl:1183: :gen_server.handle_msg/6
             (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```