### PR TITLE
allow for setting queue concurrency on the fly

### DIFF
--- a/lib/ant/queue.ex
+++ b/lib/ant/queue.ex
@@ -20,6 +20,11 @@ defmodule Ant.Queue do
     GenServer.call(get_tuple_identifier(worker.queue_name), {:dequeue, worker})
   end
 
+  def set_concurrency(queue_name, concurrency)
+      when is_binary(queue_name) and is_integer(concurrency) do
+    GenServer.call(get_tuple_identifier(queue_name), {:set_concurrency, concurrency})
+  end
+
   # Server Callbacks
 
   @impl true
@@ -114,6 +119,10 @@ defmodule Ant.Queue do
       end
 
     {:reply, :ok, %{state | processing_workers: processing_workers}}
+  end
+
+  def handle_call({:set_concurrency, concurrency}, _from, state) do
+    {:reply, :ok, %{state | concurrency: concurrency}}
   end
 
   # Helper Functions

--- a/test/queue_test.exs
+++ b/test/queue_test.exs
@@ -179,6 +179,21 @@ defmodule Ant.QueueTest do
     end
   end
 
+  test "can update concurrency on the fly" do
+    {:ok, less} =
+      Queue.start_link(queue: "less", config: [check_interval: 100, concurrency: 1])
+
+    {:ok, more} = Queue.start_link(queue: "more", config: [check_interval: 100, concurrency: 2])
+
+    assert :sys.get_state(less).concurrency == 1
+    assert :sys.get_state(more).concurrency == 2
+
+    :ok = Queue.set_concurrency("more", 5)
+
+    assert :sys.get_state(less).concurrency == 1
+    assert :sys.get_state(more).concurrency == 5
+  end
+
   defp build_worker(id, status) do
     status
     |> build_worker()


### PR DESCRIPTION
Currently the concurrency for a queue can only be set from config.
Adding a client api for Ant.Queue to set concurrency.

The use case for setting concurrency while the application is running, is that we might not know the performance of external systems that a worker is processing on, and tuning while the application is running would be beneficial to either running faster or running slower when the external system is indicating that it cannot keep up.