### PR TITLE
Race condition between queue collecting workers to process and worker setting :running status

### DIFF
--- a/lib/ant/queue.ex
+++ b/lib/ant/queue.ex
@@ -69,7 +69,7 @@ defmodule Ant.Queue do
     workers
     |> Enum.take(state.concurrency)
     |> Enum.reject(&(&1 in state.processing_workers))
-    |> Enum.map(&update_worker_to_running_status/1)
+    |> Enum.map(&Ant.Worker.update_worker_to_running_status/1)
     |> Enum.each(&run_worker/1)
 
     state = schedule_check(state)
@@ -128,18 +128,6 @@ defmodule Ant.Queue do
   end
 
   # Helper Functions
-
-  def update_worker_to_running_status(worker) do
-    {:ok, updated} =
-      Ant.Workers.update_worker(worker.id, %{
-        status: :running,
-        # prevents the same worker to be picked up later
-        scheduled_at: nil,
-        attempts: worker.attempts + 1
-      })
-
-    updated
-  end
 
   # Returns workers that remain in the non-completed state and should be re-run.
   #

--- a/lib/ant/queue.ex
+++ b/lib/ant/queue.ex
@@ -68,6 +68,8 @@ defmodule Ant.Queue do
 
     workers
     |> Enum.take(state.concurrency)
+    |> Enum.reject(&(&1 in state.processing_workers))
+    |> Enum.map(&update_worker_to_running_status/1)
     |> Enum.each(&run_worker/1)
 
     state = schedule_check(state)
@@ -126,6 +128,18 @@ defmodule Ant.Queue do
   end
 
   # Helper Functions
+
+  def update_worker_to_running_status(worker) do
+    {:ok, updated} =
+      Ant.Workers.update_worker(worker.id, %{
+        status: :running,
+        # prevents the same worker to be picked up later
+        scheduled_at: nil,
+        attempts: worker.attempts + 1
+      })
+
+    updated
+  end
 
   # Returns workers that remain in the non-completed state and should be re-run.
   #

--- a/lib/ant/worker.ex
+++ b/lib/ant/worker.ex
@@ -114,11 +114,11 @@ defmodule Ant.Worker do
     end
   end
 
-  defp update_worker_to_running_status(%Ant.Worker{status: :running} = worker) do
+  def update_worker_to_running_status(%Ant.Worker{status: :running} = worker) do
     worker
   end
 
-  defp update_worker_to_running_status(worker) do
+  def update_worker_to_running_status(worker) do
     {:ok, updated} =
       Ant.Workers.update_worker(worker.id, %{
         status: :running,

--- a/lib/ant/worker.ex
+++ b/lib/ant/worker.ex
@@ -100,18 +100,7 @@ defmodule Ant.Worker do
   end
 
   def handle_cast(:perform, state) do
-    worker = state.worker
-
-    {:ok, worker} =
-      Ant.Workers.update_worker(
-        worker.id,
-        %{
-          status: :running,
-          # prevents the same worker to be picked up later
-          scheduled_at: nil,
-          attempts: worker.attempts + 1
-        }
-      )
+    worker = state.worker |> update_worker_to_running_status()
 
     state = Map.put(state, :worker, worker)
 
@@ -123,6 +112,22 @@ defmodule Ant.Worker do
       exception ->
         handle_exception(exception, __STACKTRACE__, state)
     end
+  end
+
+  defp update_worker_to_running_status(%Ant.Worker{status: :running} = worker) do
+    worker
+  end
+
+  defp update_worker_to_running_status(worker) do
+    {:ok, updated} =
+      Ant.Workers.update_worker(worker.id, %{
+        status: :running,
+        # prevents the same worker to be picked up later
+        scheduled_at: nil,
+        attempts: worker.attempts + 1
+      })
+
+    updated
   end
 
   defp handle_result(:ok, state) do

--- a/test/queue_test.exs
+++ b/test/queue_test.exs
@@ -148,6 +148,15 @@ defmodule Ant.QueueTest do
         end
       )
 
+      expect(
+        Ant.Workers,
+        :update_worker,
+        2,
+        fn id, _ ->
+          {:ok, build_worker(:running) |> Map.put(:id, id)}
+        end
+      )
+
       interval_in_ms = 5
 
       {:ok, _pid} = Queue.start_link(queue: "default", config: [check_interval: interval_in_ms])
@@ -161,8 +170,7 @@ defmodule Ant.QueueTest do
       expect(Ant.Worker, :perform, 2, fn pid ->
         status =
           case pid do
-            :enqueued_pid_for_periodic_check -> :enqueued
-            :scheduled_pid_for_periodic_check -> :scheduled
+            :running_pid_for_periodic_check -> :running
           end
 
         send(test_pid, {:"#{status}_worker_performed", :periodic_check})
@@ -174,8 +182,7 @@ defmodule Ant.QueueTest do
 
       Process.sleep(interval_in_ms * 2)
 
-      assert_receive({:enqueued_worker_performed, :periodic_check})
-      assert_receive({:scheduled_worker_performed, :periodic_check})
+      assert_receive({:running_worker_performed, :periodic_check})
     end
   end
 


### PR DESCRIPTION
I don't yet have a good test to recreate this as it interaction between multiple GenServers, but there is a race condition between Ant.Queue `:check_workers` and Ant.Worker `:perform`

In the handle_info [function clause with the empty stuck_workers,](https://github.com/MikeAndrianov/ant/blob/b27b4e21cb85272c72e0a051756e7ec21174069a/lib/ant/queue.ex#L67) list_workers_to_process collects the workers to run.

The handling looks for :scheduled, :retry, and :enqueued states, and takes up to the concurrency limit and runs each worker.
The [Ant.Worker `:perform` handle_cast function clause](https://github.com/MikeAndrianov/ant/blob/b27b4e21cb85272c72e0a051756e7ec21174069a/lib/ant/worker.ex#L105) is currently responsible for setting the status to running.

There is a race condition in that if the :check_workers call is made again prior to the :perform call updates the status to running, the same worker will end up in the list_of_processing_workers and can have the perform called multiple times.

I have observed this running, and it appears more likely on a lower spec'd machine as the Worker GenServer is taking longer to process the messages.

2 possible solutions to fix race condition:
- update the worker before calling run_worker
- remove duplicated workers from list before calling run_worker